### PR TITLE
Add production-ready metadata to HTML

### DIFF
--- a/frontend/index.html
+++ b/frontend/index.html
@@ -4,8 +4,22 @@
     <meta charset="UTF-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <title>Conversation Wingman</title>
+    <link rel="icon" href="/favicon.ico" />
+    <meta
+      name="description"
+      content="AI-powered real-time conversation assistant"
+    />
+    <meta name="theme-color" content="#1f2937" />
+    <link rel="manifest" href="/manifest.webmanifest" />
+    <link rel="preconnect" href="https://api.openai.com" crossorigin />
+    <link
+      rel="preconnect"
+      href="https://your-project.supabase.co"
+      crossorigin
+    />
   </head>
   <body>
+    <a href="#root" class="sr-only focus:not-sr-only">Skip to content</a>
     <div id="root"></div>
     <script type="module" src="/src/main.jsx"></script>
   </body>


### PR DESCRIPTION
## Summary
- add favicon, PWA, SEO, and theme metadata to index.html
- include preconnect hints and skip-to-content link for accessibility

## Testing
- `npm test` (fails: Missing script: "test")
- `npm run build` (fails: Rollup failed to resolve import "/src/main.jsx")

------
https://chatgpt.com/codex/tasks/task_e_68c124cccec0832493a8b21c47ade7c4