### PR TITLE
feat: add React entry point using createRoot

### DIFF
--- a/frontend/src/App.jsx
+++ b/frontend/src/App.jsx
@@ -1,0 +1,7 @@
+// Conversation Wingman main component
+import React, { useState } from 'react';
+
+export default function App() {
+  const [title] = useState('Conversation Wingman');
+  return <div>{title}</div>;
+}

--- a/frontend/src/main.jsx
+++ b/frontend/src/main.jsx
@@ -1,0 +1,10 @@
+// Conversation Wingman React entry point
+import React from 'react';
+import ReactDOM from 'react-dom/client';
+import App from './App.jsx';
+
+ReactDOM.createRoot(document.getElementById('root')).render(
+  <React.StrictMode>
+    <App />
+  </React.StrictMode>
+);


### PR DESCRIPTION
## Summary
- add React 18 entry point using createRoot

## Testing
- `npm test` (fails: Missing script "test")
- `npm run build` (fails: Could not resolve "./App.jsx")

------
https://chatgpt.com/codex/tasks/task_e_68c16ffa0fc883248b3a18d612d154b7