### PR TITLE
Add PostCSS configuration

### DIFF
--- a/frontend/postcss.config.cjs
+++ b/frontend/postcss.config.cjs
@@ -1,0 +1,8 @@
+module.exports = {
+  plugins: [
+    require('tailwindcss'),
+    require('autoprefixer')({
+      overrideBrowserslist: ['>1%', 'last 2 versions', 'not dead', 'not op_mini all'],
+    }),
+  ],
+};


### PR DESCRIPTION
## Summary
- add PostCSS config loading Tailwind CSS first and Autoprefixer with modern browser targets

## Testing
- `npm test` (fails: Missing script: "test")
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68c18413c3ac8324839049ad1d0926c1