### PR TITLE
chore: scaffold Express backend

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,3 +9,26 @@ cd frontend
 npm install
 npm run dev
 ```
+
+## Backend Development
+The backend uses Node.js 20 with Express and TypeScript.
+
+```bash
+cd backend
+npm install
+npm run dev
+```
+
+Set the following environment variables:
+
+- `PORT` (optional)
+- `FRONTEND_ORIGIN`
+- `SUPABASE_URL`
+- `SUPABASE_ANON_KEY`
+
+For production:
+
+```bash
+npm run build
+npm start
+```

--- a/backend/package.json
+++ b/backend/package.json
@@ -1,0 +1,35 @@
+{
+  "name": "conversation-wingman-backend",
+  "version": "0.1.0",
+  "description": "Express backend for Conversation Wingman",
+  "main": "dist/server.js",
+  "scripts": {
+    "dev": "nodemon --watch src --exec ts-node src/server.ts",
+    "build": "tsc",
+    "start": "node dist/server.js",
+    "test": "npm run build"
+  },
+  "dependencies": {
+    "@supabase/supabase-js": "^2.45.0",
+    "cors": "^2.8.5",
+    "dotenv": "^16.4.5",
+    "express": "^4.19.2",
+    "express-rate-limit": "^6.10.0",
+    "helmet": "^7.0.0",
+    "morgan": "^1.10.0"
+  },
+  "devDependencies": {
+    "@types/cors": "^2.8.17",
+    "@types/express": "^4.17.21",
+    "@types/express-rate-limit": "^5.1.3",
+    "@types/morgan": "^1.9.7",
+    "@types/node": "^20.14.9",
+    "nodemon": "^3.1.0",
+    "ts-node": "^10.9.2",
+    "typescript": "^5.4.5"
+  },
+  "engines": {
+    "node": ">=20"
+  },
+  "license": "MIT"
+}

--- a/backend/src/config/supabase.ts
+++ b/backend/src/config/supabase.ts
@@ -1,0 +1,21 @@
+import { createClient, SupabaseClient } from '@supabase/supabase-js';
+import dotenv from 'dotenv';
+
+dotenv.config();
+
+const url = process.env.SUPABASE_URL;
+const anonKey = process.env.SUPABASE_ANON_KEY;
+
+if (!url || !anonKey) {
+  throw new Error('Missing Supabase environment variables');
+}
+
+let supabase: SupabaseClient;
+try {
+  supabase = createClient(url, anonKey);
+} catch (error) {
+  console.error('Failed to initialize Supabase client', error);
+  throw error;
+}
+
+export default supabase;

--- a/backend/src/server.ts
+++ b/backend/src/server.ts
@@ -1,0 +1,45 @@
+import express from 'express';
+import cors from 'cors';
+import helmet from 'helmet';
+import morgan from 'morgan';
+import rateLimit from 'express-rate-limit';
+import dotenv from 'dotenv';
+
+dotenv.config();
+
+const app = express();
+
+const PORT = process.env.PORT || 3000;
+const FRONTEND_ORIGIN = process.env.FRONTEND_ORIGIN || 'http://localhost:5173';
+
+app.use(cors({
+  origin: FRONTEND_ORIGIN,
+  credentials: true
+}));
+
+app.use(helmet());
+
+app.use(rateLimit({
+  windowMs: 15 * 60 * 1000,
+  max: 100
+}));
+
+app.use(express.json());
+
+app.use(morgan('combined'));
+
+const server = app.listen(PORT, () => {
+  console.log(`Server listening on port ${PORT}`);
+});
+
+const shutdown = () => {
+  server.close(() => {
+    console.log('Server closed gracefully');
+    process.exit(0);
+  });
+};
+
+process.on('SIGINT', shutdown);
+process.on('SIGTERM', shutdown);
+
+export default app;

--- a/backend/tsconfig.json
+++ b/backend/tsconfig.json
@@ -1,0 +1,12 @@
+{
+  "compilerOptions": {
+    "target": "ES2022",
+    "module": "CommonJS",
+    "rootDir": "src",
+    "outDir": "dist",
+    "esModuleInterop": true,
+    "forceConsistentCasingInFileNames": true,
+    "strict": true,
+    "skipLibCheck": true
+  }
+}


### PR DESCRIPTION
## Summary
- add Express backend package with TypeScript and middleware
- configure Supabase client for database access
- document backend setup and scripts

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68c18b23cb2c83248614db8244d598ce