### PR TITLE
Add conversation interface with audio recording and suggestion components

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,3 +41,11 @@ For production:
 npm run build
 npm start
 ```
+
+## Implemented Components
+- `AudioRecorder` – captures microphone input with visual feedback.
+- `SuggestionCards` – displays AI-generated suggestions with confidence bars and copy-to-clipboard.
+- `ConversationInterface` – main workspace integrating recording, transcription, and suggestions.
+
+## Frontend API Service
+Located at `frontend/src/services/api.js`, this client manages requests, tokens, and retries for all backend endpoints.

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -13,10 +13,11 @@
     "react-dom": "^18.2.0"
   },
   "devDependencies": {
-    "vite": "^4.5.14",
     "@vitejs/plugin-react": "^4.7.0",
-    "tailwindcss": "^3.4.17",
     "autoprefixer": "^10.4.21",
-    "postcss": "^8.5.6"
+    "postcss": "^8.5.6",
+    "tailwindcss": "^3.4.17",
+    "typescript": "^5.9.2",
+    "vite": "^4.5.14"
   }
 }

--- a/frontend/src/App.jsx
+++ b/frontend/src/App.jsx
@@ -1,7 +1,11 @@
 // Conversation Wingman main component
-import React, { useState } from 'react';
+import React from 'react';
+import ConversationInterface from './components/ConversationInterface';
 
 export default function App() {
-  const [title] = useState('Conversation Wingman');
-  return <div>{title}</div>;
+  return (
+    <div className="p-4">
+      <ConversationInterface />
+    </div>
+  );
 }

--- a/frontend/src/components/AudioRecorder.tsx
+++ b/frontend/src/components/AudioRecorder.tsx
@@ -1,0 +1,92 @@
+import React, { useEffect, useRef, useState } from 'react';
+
+interface AudioRecorderProps {
+  onRecordingComplete: (blob: Blob) => void;
+}
+
+export default function AudioRecorder({ onRecordingComplete }: AudioRecorderProps) {
+  const [isRecording, setIsRecording] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+  const [volume, setVolume] = useState(0);
+  const mediaRecorder = useRef<MediaRecorder | null>(null);
+  const chunks = useRef<Blob[]>([]);
+  const analyser = useRef<AnalyserNode | null>(null);
+  const animation = useRef<number>();
+
+  useEffect(() => {
+    return () => {
+      if (animation.current) cancelAnimationFrame(animation.current);
+      analyser.current?.disconnect();
+    };
+  }, []);
+
+  const startRecording = async () => {
+    try {
+      const stream = await navigator.mediaDevices.getUserMedia({ audio: true });
+      const context = new AudioContext();
+      const source = context.createMediaStreamSource(stream);
+      analyser.current = context.createAnalyser();
+      analyser.current.fftSize = 256;
+      source.connect(analyser.current);
+
+      mediaRecorder.current = new MediaRecorder(stream);
+      mediaRecorder.current.ondataavailable = (e) => chunks.current.push(e.data);
+      mediaRecorder.current.onstop = () => {
+        const blob = new Blob(chunks.current, { type: 'audio/webm' });
+        chunks.current = [];
+        onRecordingComplete(blob);
+      };
+      mediaRecorder.current.start();
+      setIsRecording(true);
+      visualize();
+    } catch (err) {
+      setError('Microphone access denied');
+    }
+  };
+
+  const stopRecording = () => {
+    mediaRecorder.current?.stop();
+    setIsRecording(false);
+  };
+
+  const visualize = () => {
+    if (!analyser.current) return;
+    const buffer = new Uint8Array(analyser.current.frequencyBinCount);
+    const update = () => {
+      analyser.current?.getByteTimeDomainData(buffer);
+      const max = buffer.reduce((p, c) => Math.max(p, c), 0);
+      setVolume((max - 128) / 128);
+      animation.current = requestAnimationFrame(update);
+    };
+    update();
+  };
+
+  return (
+    <div className="w-full max-w-md mx-auto p-4 border rounded-md">
+      {error && <p className="text-red-500 mb-2">{error}</p>}
+      <div className="h-4 bg-gray-200 mb-4">
+        <div
+          className="h-4 bg-green-500 transition-all"
+          style={{ width: `${Math.min(1, Math.max(0, volume)) * 100}%` }}
+        />
+      </div>
+      <div className="flex justify-center space-x-4">
+        {!isRecording ? (
+          <button
+            onClick={startRecording}
+            className="px-4 py-2 bg-blue-600 text-white rounded"
+          >
+            Start
+          </button>
+        ) : (
+          <button
+            onClick={stopRecording}
+            className="px-4 py-2 bg-red-600 text-white rounded"
+          >
+            Stop
+          </button>
+        )}
+      </div>
+    </div>
+  );
+}

--- a/frontend/src/components/ConversationInterface.jsx
+++ b/frontend/src/components/ConversationInterface.jsx
@@ -1,0 +1,95 @@
+import React, { useState } from 'react';
+import AudioRecorder from './AudioRecorder';
+import SuggestionCards from './SuggestionCards';
+import {
+  transcribeAudio,
+  suggestResponses,
+} from '../services/api';
+
+export default function ConversationInterface() {
+  const [transcript, setTranscript] = useState('');
+  const [context, setContext] = useState('');
+  const [suggestions, setSuggestions] = useState([]);
+  const [loading, setLoading] = useState(false);
+  const [topic, setTopic] = useState('');
+  const [tone, setTone] = useState('');
+  const [history, setHistory] = useState([]);
+  const [error, setError] = useState(null);
+
+  const handleAudio = async (blob) => {
+    try {
+      setLoading(true);
+      const { text } = await transcribeAudio(blob);
+      setTranscript(text);
+      setLoading(false);
+    } catch (e) {
+      setError('Transcription failed');
+      setLoading(false);
+    }
+  };
+
+  const fetchSuggestions = async () => {
+    try {
+      setLoading(true);
+      const result = await suggestResponses({ transcript, context, topic, tone });
+      setSuggestions(result.suggestions || []);
+      setHistory([...history, { transcript, suggestions: result.suggestions || [] }]);
+      setLoading(false);
+    } catch (e) {
+      setError('Suggestion fetch failed');
+      setLoading(false);
+    }
+  };
+
+  const handleFilterChange = (filters) => {
+    setTopic(filters.topic);
+    setTone(filters.tone);
+  };
+
+  return (
+    <div className="space-y-4">
+      {error && <p className="text-red-500">{error}</p>}
+      <AudioRecorder onRecordingComplete={handleAudio} />
+      <div>
+        <p className="font-semibold">Transcript</p>
+        <div className="min-h-[3rem] p-2 border rounded">{transcript}</div>
+      </div>
+      <textarea
+        value={context}
+        onChange={(e) => setContext(e.target.value)}
+        placeholder="Additional context"
+        className="w-full border p-2 rounded"
+      />
+      <button
+        onClick={fetchSuggestions}
+        className="px-4 py-2 bg-blue-600 text-white rounded"
+      >
+        Get Suggestions
+      </button>
+      <SuggestionCards
+        suggestions={suggestions}
+        loading={loading}
+        topic={topic}
+        tone={tone}
+        onFilterChange={handleFilterChange}
+      />
+      {history.length > 0 && (
+        <div>
+          <p className="font-semibold mt-4">Session History</p>
+          <ul className="space-y-2">
+            {history.map((h, i) => (
+              <li key={i} className="border p-2 rounded">
+                <p className="font-medium">{h.transcript}</p>
+                <ul className="list-disc ml-4">
+                  {h.suggestions.map((s, j) => (
+                    <li key={j}>{s.text}</li>
+                  ))}
+                </ul>
+              </li>
+            ))}
+          </ul>
+        </div>
+      )}
+    </div>
+  );
+}

--- a/frontend/src/components/SuggestionCards.jsx
+++ b/frontend/src/components/SuggestionCards.jsx
@@ -1,0 +1,63 @@
+import React from 'react';
+
+export default function SuggestionCards({
+  suggestions = [],
+  loading = false,
+  onCopy,
+  topic,
+  tone,
+  onFilterChange,
+}) {
+  const handleCopy = (text) => {
+    navigator.clipboard.writeText(text);
+    onCopy && onCopy(text);
+  };
+
+  const updateFilter = (key, value) => {
+    onFilterChange && onFilterChange({ ...{ topic, tone }, [key]: value });
+  };
+
+  return (
+    <div className="space-y-4">
+      <div className="flex space-x-2">
+        <input
+          type="text"
+          placeholder="Topic"
+          value={topic}
+          onChange={(e) => updateFilter('topic', e.target.value)}
+          className="border p-2 flex-1"
+        />
+        <input
+          type="text"
+          placeholder="Tone"
+          value={tone}
+          onChange={(e) => updateFilter('tone', e.target.value)}
+          className="border p-2 flex-1"
+        />
+      </div>
+      {loading ? (
+        <p>Loading...</p>
+      ) : (
+        <div className="grid grid-cols-1 md:grid-cols-3 gap-4">
+          {suggestions.map((s, idx) => (
+            <div key={idx} className="p-4 border rounded-md flex flex-col">
+              <p className="flex-1">{s.text}</p>
+              <div className="h-2 bg-gray-200 my-2">
+                <div
+                  className="h-2 bg-blue-500"
+                  style={{ width: `${(s.confidence || 0) * 100}%` }}
+                />
+              </div>
+              <button
+                onClick={() => handleCopy(s.text)}
+                className="mt-2 px-2 py-1 text-sm bg-green-600 text-white rounded"
+              >
+                Copy
+              </button>
+            </div>
+          ))}
+        </div>
+      )}
+    </div>
+  );
+}

--- a/frontend/src/services/api.js
+++ b/frontend/src/services/api.js
@@ -1,0 +1,66 @@
+const API_BASE_URL = import.meta.env.VITE_API_URL || '/api';
+
+let authToken = localStorage.getItem('token') || '';
+
+export const setAuthToken = (token) => {
+  authToken = token;
+  if (token) {
+    localStorage.setItem('token', token);
+  } else {
+    localStorage.removeItem('token');
+  }
+};
+
+let requestInterceptor = null;
+let responseInterceptor = null;
+
+export const setRequestInterceptor = (fn) => {
+  requestInterceptor = fn;
+};
+
+export const setResponseInterceptor = (fn) => {
+  responseInterceptor = fn;
+};
+
+const baseRequest = async (path, options = {}, retry = 1) => {
+  const opts = { ...options };
+  opts.headers = {
+    ...(opts.body instanceof FormData ? {} : { 'Content-Type': 'application/json' }),
+    ...(authToken ? { Authorization: `Bearer ${authToken}` } : {}),
+    ...opts.headers,
+  };
+
+  try {
+    const res = await fetch(`${API_BASE_URL}${path}`, opts);
+    if (!res.ok) {
+      throw new Error(await res.text());
+    }
+    const data = await res.json();
+    return data;
+  } catch (err) {
+    if (retry > 0) {
+      return baseRequest(path, options, retry - 1);
+    }
+    throw err;
+  }
+};
+
+const request = async (path, options = {}, retry = 1) => {
+  const modified = requestInterceptor ? requestInterceptor({ path, options }) : { path, options };
+  const response = await baseRequest(modified.path, modified.options, retry);
+  return responseInterceptor ? responseInterceptor(response) : response;
+};
+
+export const transcribeAudio = (file) => {
+  const form = new FormData();
+  form.append('audio', file);
+  return request('/transcribe', { method: 'POST', body: form });
+};
+
+export const suggestResponses = (payload) =>
+  request('/suggest', { method: 'POST', body: JSON.stringify(payload) });
+
+export const getFavorites = () => request('/favorites', { method: 'GET' });
+
+export const saveFavorite = (phrase) =>
+  request('/favorites', { method: 'POST', body: JSON.stringify({ phrase }) });

--- a/frontend/tsconfig.json
+++ b/frontend/tsconfig.json
@@ -1,0 +1,20 @@
+{
+  "compilerOptions": {
+    "target": "ESNext",
+    "useDefineForClassFields": true,
+    "lib": ["DOM", "DOM.Iterable", "ESNext"],
+    "allowJs": true,
+    "skipLibCheck": true,
+    "esModuleInterop": true,
+    "allowSyntheticDefaultImports": true,
+    "strict": false,
+    "forceConsistentCasingInFileNames": true,
+    "module": "ESNext",
+    "moduleResolution": "Node",
+    "resolveJsonModule": true,
+    "isolatedModules": true,
+    "noEmit": true,
+    "jsx": "react-jsx"
+  },
+  "include": ["src"]
+}


### PR DESCRIPTION
## Summary
- set up API client with token management, interceptors, and retry logic
- add AudioRecorder with microphone access, real-time visual feedback, and error handling
- add SuggestionCards for AI suggestions with confidence bars and copy support
- implement ConversationInterface integrating recorder, transcription, and suggestion workflow

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68c193c714ac8324af2c8e824c623248