### PR TITLE
feat: prepare backend for Render deployment

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,13 +19,13 @@ npm install
 npm run dev
 ```
 
-Set the following environment variables:
+Set the following environment variables (validated at startup):
 
-- `PORT` (optional)
 - `FRONTEND_ORIGIN`
 - `SUPABASE_URL`
 - `SUPABASE_ANON_KEY`
 - `OPENAI_API_KEY`
+- `PORT` (optional, defaults to `3000`)
 
 ### API Endpoints
 
@@ -38,9 +38,11 @@ Set the following environment variables:
 For production:
 
 ```bash
-npm run build
 npm start
 ```
+
+Render runs `npm install` during build, which triggers a `postinstall`
+script to compile TypeScript. The start command remains `npm start`.
 
 ## Implemented Components
 - `AudioRecorder` – captures microphone input with visual feedback.

--- a/backend/.npmrc
+++ b/backend/.npmrc
@@ -1,0 +1,2 @@
+proxy=${HTTP_PROXY}
+https-proxy=${HTTPS_PROXY}

--- a/backend/package.json
+++ b/backend/package.json
@@ -7,7 +7,8 @@
     "dev": "nodemon --watch src --exec ts-node src/server.ts",
     "build": "tsc",
     "start": "node dist/server.js",
-    "test": "npm run build"
+    "test": "npm run build",
+    "postinstall": "npm run build"
   },
   "dependencies": {
     "@supabase/supabase-js": "^2.45.0",

--- a/backend/src/config/env.ts
+++ b/backend/src/config/env.ts
@@ -1,0 +1,22 @@
+import dotenv from 'dotenv';
+
+dotenv.config();
+
+const required = [
+  'OPENAI_API_KEY',
+  'SUPABASE_URL',
+  'SUPABASE_ANON_KEY',
+  'FRONTEND_ORIGIN'
+] as const;
+
+for (const key of required) {
+  if (!process.env[key]) {
+    throw new Error(`Missing environment variable: ${key}`);
+  }
+}
+
+export const OPENAI_API_KEY = process.env.OPENAI_API_KEY!;
+export const SUPABASE_URL = process.env.SUPABASE_URL!;
+export const SUPABASE_ANON_KEY = process.env.SUPABASE_ANON_KEY!;
+export const FRONTEND_ORIGIN = process.env.FRONTEND_ORIGIN!;
+export const PORT = process.env.PORT ? parseInt(process.env.PORT, 10) : 3000;

--- a/backend/src/config/openai.ts
+++ b/backend/src/config/openai.ts
@@ -1,17 +1,9 @@
 import OpenAI from 'openai';
-import dotenv from 'dotenv';
-
-dotenv.config();
-
-const apiKey = process.env.OPENAI_API_KEY;
-
-if (!apiKey) {
-  throw new Error('Missing OpenAI API key');
-}
+import { OPENAI_API_KEY } from './env';
 
 let openai: OpenAI;
 try {
-  openai = new OpenAI({ apiKey });
+  openai = new OpenAI({ apiKey: OPENAI_API_KEY });
 } catch (error) {
   console.error('Failed to initialize OpenAI client', error);
   throw error;

--- a/backend/src/config/supabase.ts
+++ b/backend/src/config/supabase.ts
@@ -1,18 +1,9 @@
 import { createClient, SupabaseClient } from '@supabase/supabase-js';
-import dotenv from 'dotenv';
-
-dotenv.config();
-
-const url = process.env.SUPABASE_URL;
-const anonKey = process.env.SUPABASE_ANON_KEY;
-
-if (!url || !anonKey) {
-  throw new Error('Missing Supabase environment variables');
-}
+import { SUPABASE_URL, SUPABASE_ANON_KEY } from './env';
 
 let supabase: SupabaseClient;
 try {
-  supabase = createClient(url, anonKey);
+  supabase = createClient(SUPABASE_URL, SUPABASE_ANON_KEY);
 } catch (error) {
   console.error('Failed to initialize Supabase client', error);
   throw error;

--- a/backend/src/server.ts
+++ b/backend/src/server.ts
@@ -3,17 +3,12 @@ import cors from 'cors';
 import helmet from 'helmet';
 import morgan from 'morgan';
 import rateLimit from 'express-rate-limit';
-import dotenv from 'dotenv';
+import { PORT, FRONTEND_ORIGIN } from './config/env';
 import transcribeRouter from './routes/transcribe';
 import suggestRouter from './routes/suggest';
 import favoritesRouter from './routes/favorites';
 
-dotenv.config();
-
 const app = express();
-
-const PORT = process.env.PORT || 3000;
-const FRONTEND_ORIGIN = process.env.FRONTEND_ORIGIN || 'http://localhost:5173';
 
 app.use(cors({
   origin: FRONTEND_ORIGIN,


### PR DESCRIPTION
## Summary
- validate required environment variables via central env module
- compile TypeScript during Render build with postinstall hook and keep start command
- configure npm proxy handling to silence http-proxy warning

## Testing
- `npm test`
- `OPENAI_API_KEY=sk-test SUPABASE_URL=https://example.com SUPABASE_ANON_KEY=anon FRONTEND_ORIGIN=http://localhost:5173 npm start`

------
https://chatgpt.com/codex/tasks/task_e_68c19e085a048324ab5f18f6b52b71f8